### PR TITLE
增加获取raw数据到消息体

### DIFF
--- a/wxbot.py
+++ b/wxbot.py
@@ -437,12 +437,14 @@ class WXBot:
         elif mtype == 3:
             msg_content['type'] = 3
             msg_content['data'] = self.get_msg_img_url(msg_id)
+            msg_content['img']=self.session.get(msg_content['data']).content.encode('hex')
             if self.DEBUG:
                 image = self.get_msg_img(msg_id)
                 print '    %s[Image] %s' % (msg_prefix, image)
         elif mtype == 34:
             msg_content['type'] = 4
             msg_content['data'] = self.get_voice_url(msg_id)
+            msg_content['voice'] = self.session.get(msg_content['data']).content.encode('hex')
             if self.DEBUG:
                 voice = self.get_voice(msg_id)
                 print '    %s[Voice] %s' % (msg_prefix, voice)


### PR DESCRIPTION
一般都是获取到数据解耦到另外一个程序执行比如用redis做消息队列,所以把这个加到消息体中,因为只有带session的cookie…才能获取,所以内部获取就直接附加上