### PR TITLE
更新获取联系人列表的逻辑，目前超过2000人，微信会拆分获取联系人，修改gitignore，忽略temp文件夹

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ qr.png
 /*.jpg
 *.ini
 *.un~
+/temp

--- a/test.py
+++ b/test.py
@@ -22,7 +22,6 @@ def main():
     bot = MyWXBot()
     bot.DEBUG = True
     bot.conf['qr'] = 'png'
-    bot.is_big_contact = False   #如果确定通讯录过大，无法获取，可以直接配置，跳过检查。假如不是过大的话，这个方法可能无法获取所有的联系人
     bot.run()
 
 

--- a/wxbot.py
+++ b/wxbot.py
@@ -153,23 +153,35 @@ class WXBot:
 
     def get_contact(self):
         """获取当前账户的所有相关账号(包括联系人、公众号、群聊、特殊账号)"""
-        if self.is_big_contact:
-            return False
-        url = self.base_uri + '/webwxgetcontact?pass_ticket=%s&skey=%s&r=%s' \
+        dic_list = []
+        url = self.base_uri + '/webwxgetcontact?seq=0&pass_ticket=%s&skey=%s&r=%s' \
                               % (self.pass_ticket, self.skey, int(time.time()))
 
         #如果通讯录联系人过多，这里会直接获取失败
         try:
-            r = self.session.post(url, data='{}')
+            r = self.session.post(url, data='{}', timeout=180)
         except Exception as e:
-            self.is_big_contact = True
             return False
         r.encoding = 'utf-8'
+        dic = json.loads(r.text)
+        dic_list.append(dic)
+
+        while int(dic["Seq"]) != 0:
+            print "[INFO] Geting contacts. Get %s contacts for now" % dic["MemberCount"]
+            url = self.base_uri + '/webwxgetcontact?seq=%s&pass_ticket=%s&skey=%s&r=%s' \
+                      % (dic["Seq"], self.pass_ticket, self.skey, int(time.time()))
+            r = self.session.post(url, data='{}', timeout=180)
+            r.encoding = 'utf-8'
+            dic = json.loads(r.text)
+            dic_list.append(dic)
+
         if self.DEBUG:
             with open(os.path.join(self.temp_pwd,'contacts.json'), 'w') as f:
-                f.write(r.text.encode('utf-8'))
-        dic = json.loads(r.text)
-        self.member_list = dic['MemberList']
+                f.write(json.dumps(dic_list))
+
+        self.member_list = []
+        for dic in dic_list:
+            self.member_list.extend(dic['MemberList'])
 
         special_users = ['newsapp', 'fmessage', 'filehelper', 'weibo', 'qqmail',
                          'fmessage', 'tmessage', 'qmessage', 'qqsync', 'floatbottle',

--- a/wxbot.py
+++ b/wxbot.py
@@ -710,7 +710,7 @@ class WXBot:
                     with open(os.path.join(self.temp_pwd,'wxid.txt'), 'w') as f:
                         f.write(json.dumps(self.wxid_list))
                     print "[INFO] Contact list is too big. Now start to fetch member list ."
-                    self.get_big_contact()
+                    #self.get_big_contact()
 
             elif msg['MsgType'] == 37:  # friend request
                 msg_type_id = 37


### PR DESCRIPTION
web微信获取联系人的webwxgetcontact的接口新增了一个seq参数，可以根据seq参数分批获取联系人列表。