### PR TITLE
docs: fix simple typo, scaned -> scanned

### DIFF
--- a/wxbot.py
+++ b/wxbot.py
@@ -1253,7 +1253,7 @@ class WXBot:
         """
         http comet:
         tip=1, 等待用户扫描二维码,
-               201: scaned
+               201: scanned
                408: timeout
         tip=0, 等待用户确认登录,
                200: confirmed


### PR DESCRIPTION
There is a small typo in wxbot.py.

Should read `scanned` rather than `scaned`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md